### PR TITLE
Fix duplicate lock creation in spatial index builder

### DIFF
--- a/scripts/build_spatial_index.py
+++ b/scripts/build_spatial_index.py
@@ -34,9 +34,8 @@ class SpatialIndexBuilder:
         self.s3_utils = S3Utils()
         self.s3_client = self.s3_utils.get_client()
 
-        # Thread-safe counter for progress tracking
+        # Thread-safe counter and lock for progress tracking
         self.processed_count = 0
-        self.lock = threading.Lock()
         self.lock = threading.Lock()
 
     def list_all_datasets(self) -> List[str]:


### PR DESCRIPTION
## Summary
- remove redundant lock instantiation in `SpatialIndexBuilder.__init__`

## Testing
- `python -m pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_683f3e6f657c8329aac5861c6ec9566c