### PR TITLE
Remove unused imports

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -13,7 +13,6 @@ from typing import Dict, Any, Optional
 import tempfile
 import shutil
 import uuid
-import asyncio
 from datetime import datetime
 from enum import Enum
 
@@ -21,7 +20,6 @@ from fastapi import FastAPI, HTTPException, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field, validator
-import uvicorn
 from uvicorn.logging import DefaultFormatter
 
 # Add the scripts directory to the Python path so we can import the modules

--- a/scripts/process_point_cloud.py
+++ b/scripts/process_point_cloud.py
@@ -42,7 +42,6 @@ import rasterio
 from rasterio.warp import transform_bounds, reproject, Resampling
 from rasterio.transform import from_bounds
 from pyproj import Transformer, CRS
-from pyproj.exceptions import CRSError
 
 # Point cloud processing
 try:

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -14,12 +14,8 @@ from typing import Tuple, Optional
 from geopy.geocoders import Nominatim
 from geopy.exc import GeopyError
 from pyproj import Transformer, CRS
-from pyproj.exceptions import CRSError
 import numpy as np
 import laspy
-import requests
-import os
-import json
 
 # Set up logging
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- clean up duplicate imports in utils module
- trim top-level uvicorn and asyncio imports from FastAPI app
- remove unused pyproj CRSError import from point cloud script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f3e6cc30c8329bbd1d60987d67571